### PR TITLE
Add strict null checks to @pixijs/runner with destroy decorator

### DIFF
--- a/packages/runner/src/Runner.ts
+++ b/packages/runner/src/Runner.ts
@@ -1,3 +1,7 @@
+import { destroyable, destroyer } from '@pixi/utils';
+
+import type { IDestroyable } from '@pixi/utils';
+
 /**
  * A Runner is a highly performant and simple alternative to signals. Best used in situations
  * where events are dispatched to many objects at high frequency (say every frame!)
@@ -43,7 +47,7 @@
  * ```
  * @memberof PIXI
  */
-export class Runner
+export class Runner implements IDestroyable
 {
     public items: any[];
     private _name: string;
@@ -65,6 +69,7 @@ export class Runner
      * @param {...any} params - (optional) parameters to pass to each listener
      */
     /*  eslint-enable jsdoc/require-param, jsdoc/check-param-names */
+    @destroyable
     public emit(a0?: unknown, a1?: unknown, a2?: unknown, a3?: unknown,
         a4?: unknown, a5?: unknown, a6?: unknown, a7?: unknown): this
     {
@@ -117,6 +122,7 @@ export class Runner
      * The scope used will be the object itself.
      * @param {any} item - The object that will be listening.
      */
+    @destroyable
     public add(item: unknown): this
     {
         if ((item as any)[this._name])
@@ -133,6 +139,7 @@ export class Runner
      * Remove a single listener from the dispatch queue.
      * @param {any} item - The listener that you would like to remove.
      */
+    @destroyable
     public remove(item: unknown): this
     {
         const index = this.items.indexOf(item);
@@ -150,12 +157,14 @@ export class Runner
      * Check to see if the listener is already in the Runner
      * @param {any} item - The listener that you would like to check.
      */
+    @destroyable
     public contains(item: unknown): boolean
     {
         return this.items.includes(item);
     }
 
     /** Remove all listeners from the Runner */
+    @destroyable
     public removeAll(): this
     {
         this.ensureNonAliasedItems();
@@ -165,17 +174,19 @@ export class Runner
     }
 
     /** Remove all references, don't use after this. */
+    @destroyer
     public destroy(): void
     {
         this.removeAll();
-        this.items = null;
-        this._name = null;
+        this.items = [];
+        this._name = '';
     }
 
     /**
      * `true` if there are no this Runner contains no listeners
      * @readonly
      */
+
     public get empty(): boolean
     {
         return this.items.length === 0;

--- a/packages/runner/test/Runner.tests.ts
+++ b/packages/runner/test/Runner.tests.ts
@@ -24,8 +24,7 @@ describe('Runner', () =>
         complete.emit();
         expect(callback).toBeCalledTimes(3);
         complete.destroy();
-        expect(!complete.items).toBe(true);
-        expect(!complete.name).toBe(true);
+        expect('_destroyed' in complete && complete['_destroyed']).toBe(true);
     });
 
     it('should implement emit with arguments', () =>

--- a/packages/utils/src/decorator/destroy.ts
+++ b/packages/utils/src/decorator/destroy.ts
@@ -1,0 +1,91 @@
+/** Interface for classes that can be destroyed. */
+export interface IDestroyable
+{
+    destroy(): void;
+    _destroyed?: boolean;
+}
+
+/**
+ * Decorator for `destroy` method.
+ * @example
+ * ```ts
+ * class Foo implements IDestroyable
+ * {
+ *     @destroyer
+ *     public destroy(): void
+ *     {
+ *       // ...
+ *     }
+ * }
+ * ```
+ * @template This - type of the class instance
+ * @template Args - type of the arguments of a class method
+ * @template Return - type of the return value of a class method
+ * @param target - `destroy` method
+ * @param context - class method decorator context
+ * @returns decorated `destroy` method
+ */
+export function destroyer<This extends IDestroyable, Args extends any[], Return>(
+    target: (this: This, ...args: Args) => Return,
+    context: ClassMethodDecoratorContext<This, (this: This, ...args: Args) => Return>
+)
+{
+    const methodName = String(context.name);
+
+    if (methodName !== 'destroy')
+    {
+        throw new Error('Only destroy method can be decorated with @destroyer');
+    }
+
+    function decoratedDestroy(this: This): void
+    {
+        target.apply(this);
+        this._destroyed = true;
+    }
+
+    return decoratedDestroy;
+}
+
+/**
+ * Decorator for class methods that should throw an error if the class instance is destroyed.
+ * @example
+ * ```ts
+ * class Foo implements IDestroyable
+ * {
+ *     @destroyable
+ *     public bar(): void
+ *     {
+ *       // ...
+ *     }
+ *
+ *     @destroyer
+ *     public destroy(): void
+ *     {
+ *       // ...
+ *     }
+ * }
+ * ```
+ * @template This - type of the class instance
+ * @template Args - type of the arguments of a class method
+ * @template Return - type of the return value of a class method
+ * @param target - class method
+ * @param _ - class method decorator context
+ * @returns decorated class method
+ */
+export function destroyable<This extends IDestroyable, Args extends any[], Return>(
+    target: (this: This, ...args: Args) => Return,
+    _: ClassMethodDecoratorContext<This, (this: This, ...args: Args) => Return>
+)
+{
+    function decoratedMethod(this: This, ...args: Args): Return
+    {
+        if (this._destroyed)
+        {
+            throw new Error('Object is already destroyed');
+        }
+
+        return target.apply(this, args);
+    }
+
+    return decoratedMethod;
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -101,6 +101,7 @@ export * from './data/pow2';
 export * from './data/removeItems';
 export * from './data/sign';
 export * from './data/uid';
+export * from './decorator/destroy';
 export * from './logging/deprecation';
 export * from './media/BoundingBox';
 export * from './media/caches';

--- a/scripts/filterTypeScriptErrors.ts
+++ b/scripts/filterTypeScriptErrors.ts
@@ -52,7 +52,7 @@ const pathPrefixs = [
     'packages/mixin-get-global-position/',
     // 'packages/particle-container/',
     // 'packages/prepare/',
-    // 'packages/runner/',
+    'packages/runner/',
     'packages/settings/',
     // 'packages/sprite/',
     // 'packages/sprite-animated/',


### PR DESCRIPTION
##### Description of change

To eliminate the strict null check error in Runner.ts, instead of setting various properties to null when calling the destroy method, I used the _destroyed flag to prevent the use of various methods. I implemented this using a generic decorator and interface to make it universally applicable.

##### Pre-Merge Checklist

- [x] Tests and/or benchmarks are included
- [x] Documentation is changed or added
- [x] Lint process passed (`npm run lint`)
- [x] Tests passed (`npm run test`)
